### PR TITLE
Improvements

### DIFF
--- a/lib/mecks_unit/case.ex
+++ b/lib/mecks_unit/case.ex
@@ -4,12 +4,15 @@ defmodule MecksUnit.Case do
       import MecksUnit.Case
       Module.register_attribute(__MODULE__, :preserved_mocks, accumulate: true, persist: false)
       Module.register_attribute(__MODULE__, :mocks, accumulate: true, persist: false)
+      Module.register_attribute(__MODULE__, :flagged_mocks, accumulate: true, persist: false)
       @mock_index 0
     end
   end
 
   defmacro defmock({_alias, _meta, name}, options \\ [], block) do
-    preserve = Keyword.get(options, :preserve)
+    as = Keyword.get(options, :as)
+    preserve = Keyword.get(options, :preserve) || !is_nil(as)
+    attributes = Keyword.get(options, :attributes)
 
     quote do
       postfix = if unquote(preserve), do: "__INDEX__", else: @mock_index
@@ -18,21 +21,43 @@ defmodule MecksUnit.Case do
         Enum.join([__MODULE__, postfix]),
         unquote_splicing(List.wrap(name))
       ])
+
+      attrs = if unquote(attributes), do:
+        Enum.map(unquote(attributes), fn attr ->
+          val = Module.get_attribute(__MODULE__, attr, :default)
+          if val == :default do
+            nil
+          else
+            {:@, [line: 0], [{attr, [line: 0], [ Macro.escape(val) ]}]}
+          end
+        end)
+        |> Enum.filter(&(&1 != nil)),
+      else: []
+
       block = unquote(Macro.escape(block))
 
-      if unquote(preserve) do
-        @preserved_mocks {name, block}
-      else
-        @mocks {name, block}
+      cond do
+        unquote(as) != nil -> @flagged_mocks {unquote(as), name, attrs ++ block}
+        unquote(preserve)  -> @preserved_mocks {name, attrs ++ block}
+        true               -> @mocks {name, attrs ++ block}
       end
     end
   end
 
-  defmacro mocked_test(message, pattern \\ nil, block) do
-    args = if pattern == nil, do: [message], else: [message, pattern]
+  defmacro mocked_test(message, options \\ [], pattern \\ nil, block) do
+      {options, pattern} = cond do
+        Keyword.keyword?(options) -> {options, pattern} 
+        true -> {[], options}
+      end
+      args = if pattern != nil, do: [message, pattern], else: [message]
 
     quote do
-      MecksUnit.define_mocks(Enum.reverse(@preserved_mocks) ++ @mocks, __MODULE__, @mock_index)
+      used_flags = if unquote(options) != nil, do: Keyword.get(unquote(options), :use), else: nil
+      used_mocks = if used_flags != nil, do: Enum.filter(Enum.map(@flagged_mocks, fn
+        {k, n, b} -> if k in used_flags, do: {n, b}, else: nil
+      end), &(&1 != nil)), else: []
+
+      MecksUnit.define_mocks(Enum.reverse(@preserved_mocks) ++ @mocks ++ used_mocks, __MODULE__, @mock_index)
 
       test unquote_splicing(args) do
         mock_env = Enum.join([__MODULE__, @mock_index])


### PR DESCRIPTION
- Fix problem with using args like `--exclude db` (issue #4)
- Allow to add @attributes inside `@defmock`
- Added feature (useful to keep mocks & tests separated): `defmock MyMock, as: mock1` + `mocked_test "my test", use: [:mock1]`
- Added feature to copy @attributes into mock with `@attr1 "abc"` (in test module, not mock) + `defmock MyMock, attributes: [:attr1]`

- TIP: Don't use aliases for `defmock` !